### PR TITLE
Update testing.md 

### DIFF
--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -32,7 +32,7 @@ Java
 
 ## Testing with an embedded Kafka server
 
-To test the Alpakka Kafka connector the [Embedded Kafka library](https://github.com/manub/scalatest-embedded-kafka) is an important tool as it helps to easily start and stop Kafka brokers from test cases.
+To test the Alpakka Kafka connector the [Embedded Kafka library](https://github.com/embeddedkafka/embedded-kafka) is an important tool as it helps to easily start and stop Kafka brokers from test cases.
 
 The testkit contains helper classes used by the tests in the Alpakka Kafka connector and may be used for other testing, as well.
 


### PR DESCRIPTION
In alpakka-kafka docs for testing, change the 'Embedded Kafka Library' link, in order to reference the maintained fork of the project.
The new repo is referenced by the author of the main repository in this closed PR:
https://github.com/manub/scalatest-embedded-kafka/pull/169https://github.com/manub/scalatest-embedded-kafka/pull/169